### PR TITLE
Support passing cmake args to VTK build via env var

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -56,6 +56,9 @@ if(VTKPythonPackage_SUPERBUILD)
   option(VTKPythonPackage_BUILD_PYTHON "Build VTK python module" ON)
   mark_as_advanced(VTKPythonPackage_BUILD_PYTHON)
 
+  option(VTK_Group_Web "Build VTK web module" OFF)
+  mark_as_advanced(VTK_Group_Web)
+
 
   #-----------------------------------------------------------------------------
   include(ExternalProject)
@@ -200,6 +203,9 @@ if(VTKPythonPackage_SUPERBUILD)
       # Rendering options
       -DVTK_Group_Qt:BOOL=OFF  # XXX Enabled this later
       -DVTK_RENDERING_BACKEND:STRING=OpenGL2
+
+      # Module options
+      -DVTK_Group_Web:BOOL=${VTK_Group_Web}
 
       ${ep_common_cmake_cache_args}
     USES_TERMINAL_DOWNLOAD 1

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,8 @@
-
 from __future__ import print_function
-from os import sys, path
+
+import os
+import shlex
+import sys
 
 try:
     from skbuild import setup
@@ -11,7 +13,7 @@ except ImportError:
     print('  python -m pip install scikit-build')
     sys.exit(1)
 
-sys.path.append(path.dirname(path.dirname(path.abspath(__file__))))
+sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 from vtkVersion import get_versions
 
 setup(
@@ -21,7 +23,7 @@ setup(
     author_email='vtk-developers@vtk.org',
     packages=['vtk'],
     package_dir={'vtk': 'vtk'},
-    cmake_args=[],
+    cmake_args=shlex.split(os.environ.get('VTK_CMAKE_ARGS', '')),
     py_modules=[
         'vtkVersion',
     ],


### PR DESCRIPTION
The env var VTK_CMAKE_ARGS can be used to pass a list of args to
the scikit-build configure step of VTK.

This commit also exposes the VTK_Group_Web flag to the outer
build process as a CMake variable.