### PR TITLE
Create Dockerfile for vtk python + web lib using OSMesa

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,11 @@
+FROM python:3.6
+MAINTAINER Zach Mullen <zach.mullen@kitware.com>
+
+RUN apt-get update && apt-get install -y libglapi-mesa libosmesa6 freeglut3-dev && \
+    pip install cmake ninja scikit-build
+
+COPY . /VTKPythonPackage
+
+RUN cd VTKPythonPackage && \
+    VTK_CMAKE_ARGS="-DVTK_Group_Web:BOOL=ON" python setup.py bdist_wheel
+RUN pip install /VTKPythonPackage/dist/vtk-*.whl


### PR DESCRIPTION
@jcfr I don't know if this is the right place for this Dockerfile, it may not be generic enough, but it does have some generally useful properties. To test, run

```
docker build -t vtk-python .
docker run -i -t vtk-python
```

It inherits the default entrypoint from the python image, so it should open a python 3.6 REPL. There, you should be able to do `import vtk` and `import vtk.web`.