### PR TITLE
Update git tag to fix mac compilation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -74,7 +74,7 @@ if(VTKPythonPackage_SUPERBUILD)
 
   set(VTK_REPOSITORY "https://github.com/kitware/VTK.git")
   # VTK nightly-master 2017-07-17
-  set(VTK_GIT_TAG "2a775bf")
+  set(VTK_GIT_TAG "8a60be1")
 
   #-----------------------------------------------------------------------------
   # A separate project is used to download VTK, so that it can reused


### PR DESCRIPTION
The bug discussed [here](http://vtk.1045678.n5.nabble.com/Uploading-Packages-to-PyPi-td5744959.html) making the build fail on macOS has already been [fixed on VTK](https://github.com/Kitware/VTK/commit/8a60be1efb14ced6085d5f4260053cdfb4333ec8). This PR simply sets the git tag to the first compatible version.

Please note that the bug was reintroduced in v8.0.1. I opened an [issue](https://gitlab.kitware.com/vtk/vtk/issues/17200) about it.