### PR TITLE
Get package working on OSX.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -69,7 +69,7 @@ if(VTKPythonPackage_SUPERBUILD)
     set(NOT_VTK_OPENGL_HAS_OSMESA ON)
   endif()
 
-  if(APPLE)
+  if(APPLE OR WIN32)
     set(VTK_BUILD_WITH_X OFF)
   else()
     set(VTK_BUILD_WITH_X ${NOT_VTK_OPENGL_HAS_OSMESA})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -69,12 +69,18 @@ if(VTKPythonPackage_SUPERBUILD)
     set(NOT_VTK_OPENGL_HAS_OSMESA ON)
   endif()
 
+  if(APPLE)
+    set(VTK_BUILD_WITH_X OFF)
+  else()
+    set(VTK_BUILD_WITH_X ${NOT_VTK_OPENGL_HAS_OSMESA})
+  endif()
+
   #-----------------------------------------------------------------------------
   include(ExternalProject)
 
   set(VTK_REPOSITORY "https://github.com/kitware/VTK.git")
   # VTK nightly-master 2017-07-17
-  set(VTK_GIT_TAG "8a60be1")
+  set(VTK_GIT_TAG "v8.1.0")
 
   #-----------------------------------------------------------------------------
   # A separate project is used to download VTK, so that it can reused
@@ -176,6 +182,11 @@ if(VTKPythonPackage_SUPERBUILD)
     list(APPEND ep_common_cmake_cache_args
       -DCMAKE_INSTALL_RPATH:STRING=$ORIGIN
       )
+  elseif(APPLE)
+    list(APPEND ep_common_cmake_cache_args
+      -DCMAKE_INSTALL_NAME_DIR:STRING=@loader_path
+      -DCMAKE_INSTALL_RPATH:STRING=@loader_path
+      )
   endif()
 
   ExternalProject_add(VTK
@@ -213,7 +224,7 @@ if(VTKPythonPackage_SUPERBUILD)
       -DVTK_Group_Qt:BOOL=OFF  # XXX Enabled this later
       -DVTK_RENDERING_BACKEND:STRING=OpenGL2
       -DVTK_OPENGL_HAS_OSMESA:BOOL=${VTK_OPENGL_HAS_OSMESA}
-      -DVTK_USE_X:BOOL=${NOT_VTK_OPENGL_HAS_OSMESA}
+      -DVTK_USE_X:BOOL=${VTK_BUILD_WITH_X}
 
       # Module options
       -DVTK_Group_Web:BOOL=${VTK_Group_Web}

--- a/scripts/osx_build_wheels.py
+++ b/scripts/osx_build_wheels.py
@@ -1,0 +1,61 @@
+import glob
+import os
+import shutil
+from subprocess import check_call
+import sys
+
+SCRIPT_DIR = os.path.dirname(__file__)
+ROOT_DIR = os.path.abspath(os.path.join(SCRIPT_DIR, ".."))
+STANDALONE_DIR = os.path.join(ROOT_DIR, "standalone-build")
+PROJECT_NAME = "VTK"
+
+
+def get_python_info():
+    py_exe = sys.executable
+    version = sys.version_info[:2]
+    py_ver = '{0}.{1}'.format(*version)
+    prefix = os.path.abspath(sys.prefix)
+    py_inc_dir = glob.glob(os.path.join(prefix, 'include', 'python*'))[0]
+    py_lib_dir = os.path.join(prefix, 'lib')
+    py_lib = os.path.join(py_lib_dir, 'libpython%s.dylib' % py_ver)
+    return py_exe, py_ver, py_inc_dir, py_lib
+
+
+def build_wheel(cleanup=False):
+    py_exe, py_ver, py_inc_dir, py_lib = get_python_info()
+    build_type = 'Release'
+    source_path = "%s/%s-source" % (STANDALONE_DIR, PROJECT_NAME)
+    build_path = "%s/%s-osx_%s" % (ROOT_DIR, PROJECT_NAME, py_ver)
+
+    # Clean up previous invocations
+    if cleanup and os.path.exists(build_path):
+        shutil.rmtree(build_path)
+
+    print("#")
+    print("# Build single %s wheel" % PROJECT_NAME)
+    print("#")
+
+    # Generate wheel
+    check_call([
+        py_exe,
+        "setup.py", "bdist_wheel",
+        "--build-type", build_type,
+        "-G", "Ninja",
+        "--",
+        "-DVTK_SOURCE_DIR:PATH=%s" % source_path,
+        "-DVTK_BINARY_DIR:PATH=%s" % build_path,
+        "-DPYTHON_EXECUTABLE:FILEPATH=%s" % py_exe,
+        "-DPYTHON_INCLUDE_DIR:PATH=%s" % py_inc_dir,
+        "-DPYTHON_LIBRARY:FILEPATH=%s" % py_lib
+    ])
+
+    # Cleanup
+    check_call([py_exe, "setup.py", "clean"])
+
+
+def main():
+    build_wheel()
+
+
+if __name__ == '__main__':
+    main()

--- a/vtkVersion.py
+++ b/vtkVersion.py
@@ -1,4 +1,4 @@
-VERSION = '8.0.0.dev20170717+413.g2a775bf'
+VERSION = '8.1.0'
 
 def get_versions():
     """Returns versions for the VTK Python package.


### PR DESCRIPTION
- Added a simple build script in `scripts/osx_build_wheels.py`.
- Also bumps up version to 8.1.0 since that is the latest public
  release.

@jcfr -- this seems to work well for me.  Please let me know if you'd like me to make any changes.  It would be great if this could be merged.  It also includes a fix for issue #10.